### PR TITLE
Added a trivial setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from distutils.core import setup
+setup(name='pybam',
+        version='1.0',
+        py_modules=['pybam'],
+        )


### PR DESCRIPTION
Hi John

First of all, thanks a lot for this module. It works like a charm, and I really like its interface.

I'm using it in one of my projects as a dependency and I've found it hard to come up with a clean way of installing pybam and setting up the paths automatically. This pull-request adds a trivial setup.py which will allow people to install pybam with pip:
```
$ pip install https://github.com/JohnLonginotto/pybam/zipball/master
```
Note that you don't need to publish it on PyPI since `pip` supports http

Regards,
Matthieu